### PR TITLE
V1.0.1 dev

### DIFF
--- a/docs/3.0. Core_models.md
+++ b/docs/3.0. Core_models.md
@@ -127,8 +127,6 @@ Example:
 
 ## 7. Senders
 
-Event senders require a new string field called `event_type_definition_href` in order to host a reference to the definition file for the event type used by the associated source.
-
 The supported transports will be extended to include:
 
 * urn:x-nmos:transport:mqtt
@@ -154,7 +152,6 @@ Example:
     "device_id": "58f6b536-ca4c-43fd-880a-9df2501fc125",
     "flow_id": "0554b43a-ea7c-418d-a39e-1205ee281af3",
     "manifest_href": "",
-    "event_type_definition_href": "http://127.0.0.1:8050/x-nmos/events/v1.0/sources/68f519a3-5523-4b2c-b72d-ec23cc80207d/type",
     "version": "1529676926:000000000"
 }
 ```
@@ -202,6 +199,8 @@ Example:
 For connection management of resource defined in this specification only IS-05 connection management should be used, i.e. not the legacy IS-04 connection management.
 
 Two new transport parameters to be used in a `PATCH` request are defined in this specification:
+
 * `event_address`
 * `event_rest_url`
+
 The value of the `event_address` parameter varies between transports. The usage will be detailed in each transport section. The parameter `event_rest_url` should point to the event type definition object that can be acquired using a `GET` request.

--- a/docs/4.1. Transport - MQTT.md
+++ b/docs/4.1. Transport - MQTT.md
@@ -26,7 +26,7 @@ Only IS-05 connection management will be used for connection management of resou
 
 ### 3.1 event_address
 
-The `event_address` parameter will hold the MQTT topic and will always be set to the sender id, prefixed with `x-nmos/source/` for easier filtering.
+The `event_address` parameter will hold the MQTT topic and will always be set to the source id, prefixed with `x-nmos/source/` for easier filtering.
 
 ### 3.2 event_rest_url
 

--- a/docs/4.2. Transport - Websocket.md
+++ b/docs/4.2. Transport - Websocket.md
@@ -102,7 +102,7 @@ Upon connection, a client needs to initialise its subscription list by sending a
 After establishing the subscription list, the client will start receiving events only for the items it has subscribed to.
 A client may choose to add or remove items to its subscription at any point in time.
 
-Each time a client updates its subscriptions list (sends a new subscription command), the server will resend all the current states for each of the subscribed senders. If a client needs to reconnect, then the WebSocket session context needs to be re-established so the client will send a new subscription command re-initialising its subscription.
+Each time a client updates its subscriptions list (sends a new subscription command), the server will resend all the current states for each of the subscribed sources. If a client needs to reconnect, then the WebSocket session context needs to be re-established so the client will send a new subscription command re-initialising its subscription.
 
 A subscription command will only get sent out as a consequence of an NMOS Connection Management action or a reconnection.
 
@@ -134,7 +134,7 @@ Example
 ```json
 {
   "command": "subscription",
-  "senders": [
+  "sources": [
     "772116e0-b4ba-43b1-9ffc-70287c17cb9e",
     "674e32cb-84b5-475e-b7db-7821530c4375"
   ]
@@ -143,11 +143,11 @@ Example
 
 #### Step 3
 
-The client receives the initial state for each sender in its subscription list thus solving the problem of late joiners.
+The client receives the initial state for each source in its subscription list thus solving the problem of late joiners.
 
 #### Step 4
 
-The client continues to receive events only from the subscribed senders.
+The client continues to receive events only from the subscribed sources.
 
 #### Step 5
 
@@ -155,6 +155,6 @@ The client issues health commands every 60 seconds as described above.
 
 ## 5. Late joiners
 
-As described above a client will receive the initial states for all the senders in its subscription list.
+As described above a client will receive the initial states for all the sources in its subscription list.
 
 A client may also choose to query the REST API using `event_rest_url` to access the latest state of an emitter in order to verify the current state.

--- a/docs/4.2. Transport - Websocket.md
+++ b/docs/4.2. Transport - Websocket.md
@@ -44,7 +44,7 @@ Example
             "href": "http://hostname/x-nmos/connection/v1.0/"
         },
         {
-            "type": "urn:x-nmos:events:query:states/v1.0",
+            "type": "urn:x-nmos:events:query/v1.0",
             "href": "http://hostname/x-nmos/events/v1.0/"
         },
         {

--- a/docs/4.3. Transport - AMQP.md
+++ b/docs/4.3. Transport - AMQP.md
@@ -26,7 +26,7 @@ Only IS-05 connection management will be used for connection management of resou
 
 ### 3.1 event_address
 
-The `event_address` parameter will hold the AMQP topic and will always be set to the sender id, prefixed with `x-nmos/source/` for easier filtering.
+The `event_address` parameter will hold the AMQP topic and will always be set to the source id, prefixed with `x-nmos/source/` for easier filtering.
 
 ### 3.2 event_rest_url
 

--- a/docs/4.3. Transport - AMQP.md
+++ b/docs/4.3. Transport - AMQP.md
@@ -26,7 +26,7 @@ Only IS-05 connection management will be used for connection management of resou
 
 ### 3.1 event_address
 
-The `event_address` parameter will hold the AMQP topic and will always be set to the source id, prefixed with `x-nmos/source/` for easier filtering.
+The `event_address` parameter will hold the AMQP topic and will always be set to the source id, prefixed with `x-nmos.source.` for easier filtering.
 
 ### 3.2 event_rest_url
 

--- a/docs/5.0. Rest_api_late_joiners.md
+++ b/docs/5.0. Rest_api_late_joiners.md
@@ -9,10 +9,11 @@ Other sections can be accessed from the [Overview](1.0.%20Overview.md).
 ## 1. Introduction
 
 The late joiners API is meant as a protocol agnostic means by which a consumer (receiver) can get in sync with the last known state of an event emitter. The API *has to be* used only together with other event based transports to minimize the load on the device allowing for better scalability. The main purpose of the API is resolving the problem of late joiners but it can be also used for low-frequency sanity checks of the states for signals that change states very rarely.
+The API also allows for a consumer to find the type definition associated with a source event type.
 
 ## 2. NMOS Resource
 
-The API will be hosted under an NMOS device in the `controls` array using the `urn:x-nmos:events:query:states` type.
+The API will be hosted under an NMOS device in the `controls` array using the `urn:x-nmos:events:query` type.
 
 Example
 
@@ -48,12 +49,29 @@ Example
 
 ## 3. Usage
 
-Clients need to append `/sources/` and a source id to the href in order to access the state of that source via a `GET` request.
-The response will always be the current state of the emitter as if the receiver would have received the state using its transport protocol.
+The api base will return the following path upon a successful Get request:
 
-Example request:  
+```json
+[
+    "sources/"
+]
+```
 
-`GET http://hostname/x-nmos/events/v1.0/sources/a65c15a4-a52e-4960-8cd2-e05c31196e5f`
+The api `sources/id` path will return the following upon a successful Get request
+
+```json
+[
+    "state/",
+    "type/"
+]
+```
+
+The `state` path allows for consumers to retrieve the latest state of the source whereas the `type` path allows for the retrieval
+of the type definition associated with the event type of the source.
+
+Example of retrieving the `state` of a source:
+
+`GET http://hostname/x-nmos/events/v1.0/sources/a65c15a4-a52e-4960-8cd2-e05c31196e5f/state`
 
 Example response:  
 
@@ -70,6 +88,18 @@ Example response:
   "payload": {
     "value": true
   }
+}
+```
+
+Example of retrieving the `type` definition for a source:
+
+`GET http://hostname/x-nmos/events/v1.0/sources/a65c15a4-a52e-4960-8cd2-e05c31196e5f/type`
+
+Example response:  
+
+```json
+{
+  "type": "boolean"
 }
 ```
 

--- a/docs/5.0. Rest_api_late_joiners.md
+++ b/docs/5.0. Rest_api_late_joiners.md
@@ -32,7 +32,7 @@ Example
             "href": "http://hostname/x-nmos/connection/v1.0/"
         },
         {
-            "type": "urn:x-nmos:events:query:states/v1.0",
+            "type": "urn:x-nmos:events:query/v1.0",
             "href": "http://hostname/x-nmos/events/v1.0/"
         }
     ],


### PR DESCRIPTION
Just changing "sender_id" to "source_id" as agreed in the workshop
Also changed the topic prefix delimiters for AMQP from / to .
Removed "event_type_definition_href" from the sender as we are hosting the type in the Rest API
Renamed urn:x-nmos:events:query:states/v1.0 to urn:x-nmos:events:query/v1.0
Added examples and details on how to query the source type definition using the Rest API