### PR TITLE
Some more changes which have been omitted

### DIFF
--- a/docs/2.0. Event_types.md
+++ b/docs/2.0. Event_types.md
@@ -16,7 +16,7 @@ These are the supported event types:
 * enum
 * object
 
-The types are identified by the corresponding values in the event_type field in an event message and the NMOS source. When additional restrictions are applied to an event type, the *type definition object* will be provided using the REST API and the corresponding URL will be defined in the `event_type_definition_href` field of the NMOS sender. The type definition object will always define the type of the `value` field and can define restrictions on the value.
+The types are identified by the corresponding values in the event_type field in an event message and the NMOS source. When additional restrictions are applied to an event type, the *type definition object* will be provided using the REST API (see [REST API (Late joiners)](5.0.%20Rest_api_late_joiners.md)). The type definition object will always define the type of the `value` field and can define restrictions on the value.
 
 ## 2. Base types
 
@@ -343,6 +343,7 @@ _Type definition_:
 _The usage of the `object` event type is out of scope of this specification, but it might be used by future specifications that could use the APIs and transports defined here._
 
 The *object* event type has to be associated with a type definition object that has to provide the object structure. It will consist of fields that can have following types:
+
 * other base types (boolean, number, string, enum)
 * other objects
 * arrays of other base types or objects
@@ -361,7 +362,7 @@ More details about NMOS resources in the section [Core models](3.0 Core_models.m
 
 The wildcard allows a smart receiver to advertise a wider capability with a specific category above. This is useful information when building a user interface which handles connection management but also matches capabilities between senders and receivers.
 
-An example of a receiver which may use a wildcard could be a smart software gauge which can autocalibrate. This could advertise its capability as `number/*`.
+An example of a receiver which may use a wildcard could be a smart software gauge which can auto-calibrate. This could advertise its capability as `number/*`.
 
 Another example could be for a temperature receiver which supports any measurement unit. This could advertise its capability as `number/Temperature/*`.
 


### PR DESCRIPTION
removed mention of "event_type_definition_href" as it is now available in the Rest API