### PR TITLE
Make docs match schema and example

### DIFF
--- a/docs/6.0. Event and tally rest api.md
+++ b/docs/6.0. Event and tally rest api.md
@@ -62,8 +62,8 @@ The api `sources/id` path will return the following upon a successful Get reques
 
 ```json
 [
-    "state",
-    "type"
+    "state/",
+    "type/"
 ]
 ```
 


### PR DESCRIPTION
See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.x/APIs/schemas/source.json and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.x/examples/eventsapi-v1.0-sourceid-get-200.json