### PR TITLE
Fix missing definition of 'Event' RAML type

### DIFF
--- a/APIs/EventsAPI.raml
+++ b/APIs/EventsAPI.raml
@@ -14,10 +14,8 @@ types:
     type: !include schemas/sources.json
   Source:
     type: !include schemas/source.json
-  EventCore:
-    type: !include schemas/event_core.json
-  EventNumber:
-    type: !include schemas/event_number.json
+  Event:
+    type: !include schemas/event.json
   Type:
     type: !include schemas/type.json
   ErrorSchema:


### PR DESCRIPTION
EventsAPI.raml definition of the `/sources/{sourceId}/state` endpoint refers to the RAML type `Event`. However this is not found in the `types:` section, instead we have `EventCore` and `EventNumber` (which aren't used).

I know the rendering by **raml2html** isn't very helpful with 'oneOf' or 'anyOf' schemas like [schemas/type.json](https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.x/APIs/schemas/type.json) or [schemas/event.json](https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.x/APIs/schemas/event.json), because you can't navigate from that schema to the element schemas (event_boolean.json, event_number.json, etc.). For example, see how the 'Response' is rendered in [GET /sources/{sourceId}/type](https://amwa-tv.github.io/nmos-event-tally/tags/v1.0/html-APIs/EventsAPI.html#sources__sourceid__type_get).

However, I think it's still more correct to use an `Event` RAML type that refers to [schemas/event.json](https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.x/APIs/schemas/event.json) (and that would be consistent with the defined `Type` type for the `/sources/{sourceId}/type` endpoint) rather than to create a [RAML union type](https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md#union-type) of `EventBoolean | EventNumber | EventString | EventObject` (and definitions of those).