### PR TITLE
Fix event type regex

### DIFF
--- a/APIs/schemas/event_boolean.json
+++ b/APIs/schemas/event_boolean.json
@@ -16,7 +16,7 @@
         "event_type": {
           "description": "Event type",
           "type": "string",
-          "pattern": "^boolean(?:\\/[a-zA-Z_\\-])*$"
+          "pattern": "^boolean(\\/[a-zA-Z_\\-]+)*$"
         },
         "payload": {
           "description": "Boolean payload",

--- a/APIs/schemas/event_boolean.json
+++ b/APIs/schemas/event_boolean.json
@@ -16,7 +16,7 @@
         "event_type": {
           "description": "Event type",
           "type": "string",
-          "pattern": "^boolean(\\/[a-zA-Z_\\-]+)*$"
+          "pattern": "^boolean(\\/[^\\s\\/]+)*$"
         },
         "payload": {
           "description": "Boolean payload",

--- a/APIs/schemas/event_number.json
+++ b/APIs/schemas/event_number.json
@@ -16,7 +16,7 @@
         "event_type": {
           "description": "Event type",
           "type": "string",
-          "pattern": "^number(\\/[a-zA-Z_\\-]+)*$"
+          "pattern": "^number(\\/[^\\s\\/]+)*$"
         },
         "payload": { "$ref": "number.json" }
       }

--- a/APIs/schemas/event_number.json
+++ b/APIs/schemas/event_number.json
@@ -16,7 +16,7 @@
         "event_type": {
           "description": "Event type",
           "type": "string",
-          "pattern": "^number(?:\\/[a-zA-Z_\\-])*$"
+          "pattern": "^number(\\/[a-zA-Z_\\-]+)*$"
         },
         "payload": { "$ref": "number.json" }
       }

--- a/APIs/schemas/event_object.json
+++ b/APIs/schemas/event_object.json
@@ -16,7 +16,7 @@
         "event_type": {
           "description": "Event type",
           "type": "string",
-          "pattern": "^object(\\/[a-zA-Z_\\-]+)*$"
+          "pattern": "^object(\\/[^\\s\\/]+)*$"
         },
         "payload": {
           "description": "Object payload",

--- a/APIs/schemas/event_object.json
+++ b/APIs/schemas/event_object.json
@@ -16,7 +16,7 @@
         "event_type": {
           "description": "Event type",
           "type": "string",
-          "pattern": "^object(?:\\/[a-zA-Z_\\-])*$"
+          "pattern": "^object(\\/[a-zA-Z_\\-]+)*$"
         },
         "payload": {
           "description": "Object payload",

--- a/APIs/schemas/event_string.json
+++ b/APIs/schemas/event_string.json
@@ -16,7 +16,7 @@
         "event_type": {
           "description": "Event type",
           "type": "string",
-          "pattern": "^string(\\/[a-zA-Z_\\-]+)*$"
+          "pattern": "^string(\\/[^\\s\\/]+)*$"
         },
         "payload": {
           "description": "String payload",

--- a/APIs/schemas/event_string.json
+++ b/APIs/schemas/event_string.json
@@ -16,7 +16,7 @@
         "event_type": {
           "description": "Event type",
           "type": "string",
-          "pattern": "^string(?:\\/[a-zA-Z_\\-])*$"
+          "pattern": "^string(\\/[a-zA-Z_\\-]+)*$"
         },
         "payload": {
           "description": "String payload",


### PR DESCRIPTION
Would resolve #29. First commit fixes the bug in v1.0 "event_type" regexes, second commit relaxes the regexes slightly as discussed in in the issue.
