### PR TITLE
A Sender's 'manifest_href' is permitted to be null

### DIFF
--- a/docs/4.0. Core models.md
+++ b/docs/4.0. Core models.md
@@ -77,6 +77,8 @@ The supported transports have been extended to include:
 * urn:x-nmos:transport:mqtt
 * urn:x-nmos:transport:websocket
 
+Neither of these transport types require a transport file (`manifest_href`).
+
 Example:
 
 ```json
@@ -95,7 +97,7 @@ Example:
     "id": "68f519a3-5523-4b2c-b72d-ec23cc80207d",
     "device_id": "58f6b536-ca4c-43fd-880a-9df2501fc125",
     "flow_id": "0554b43a-ea7c-418d-a39e-1205ee281af3",
-    "manifest_href": "",
+    "manifest_href": null,
     "version": "1529676926:000000000"
 }
 ```


### PR DESCRIPTION
…when the transport type does not require a transport file.

Depends on https://github.com/AMWA-TV/nmos-discovery-registration/pull/97 being merged.

Resolves #38.
