### PR TITLE
Clarification of the "number" type

### DIFF
--- a/APIs/schemas/number.json
+++ b/APIs/schemas/number.json
@@ -12,8 +12,9 @@
       "type": "number"
     },
     "scale": {
-      "description": "Denominator for rational number representation",
-      "type": "integer"
+      "description": "Denominator for rational number representation (default = 1)",
+      "type": "integer",
+      "minimum": 1
     }
   }
 }

--- a/APIs/schemas/receiver_transport_params_ext.json
+++ b/APIs/schemas/receiver_transport_params_ext.json
@@ -10,7 +10,7 @@
         "string",
         "null"
       ],
-      "description": "the event and tally rest api url targeting the associated source"
+      "description": "the URL for the Events API resource for the associated source"
     },
     "ext_is_07_source_id": {
       "type": [

--- a/APIs/schemas/receiver_transport_params_ext.json
+++ b/APIs/schemas/receiver_transport_params_ext.json
@@ -1,8 +1,8 @@
 {
   "$id": "https://www.amwa.tv/event_and_tally/receiver_transport_params_ext.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Describes external Sender transport parameters defined for IS-07 NMOS Event & Tally specification. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint.",
-  "title": "External Sender Transport Parameters",
+  "description": "Describes external Receiver transport parameters defined for IS-07 NMOS Event & Tally specification. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint.",
+  "title": "External Receiver Transport Parameters",
   "type": "object",
   "properties": {
     "ext_is_07_rest_api_url": {

--- a/APIs/schemas/sender_transport_params_ext.json
+++ b/APIs/schemas/sender_transport_params_ext.json
@@ -7,7 +7,7 @@
   "properties": {
     "ext_is_07_rest_api_url": {
       "type": "string",
-      "description": "the event and tally rest api url targeting the associated source"
+      "description": "the URL for the Events API resource for the associated source"
     },
     "ext_is_07_source_id": {
       "type": "string",

--- a/APIs/schemas/type_number.json
+++ b/APIs/schemas/type_number.json
@@ -19,7 +19,7 @@
       ]
     },
     "scale": {
-      "description": "Denominator value in case of rational numbers used for defining min, max and step.",
+      "description": "Denominator typically used for rational numbers in the event payload",
       "type": "integer",
       "minimum": 1
     },

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AMWA IS-07 NMOS Event & Tally Specification
 
-This repository contains details of this AMWA Specification, including message types, event types, core models, transports, rest api and measurement units guidelines.
+This repository contains details of this AMWA Specification, including message types, event types, core models, transports, REST API and measurement units guidelines.
 
 ## Getting started
 

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -17,6 +17,6 @@ The specification is split into the following sections:
 * [Core models](4.0.%20Core%20models.md)
 * [Transports](5.0.%20Transports.md)
   * [MQTT](5.1.%20Transport%20-%20MQTT.md)
-  * [Websocket](5.2.%20Transport%20-%20Websocket.md)  
-* [Event & Tally REST API](6.0.%20Event%20and%20tally%20rest%20api.md)
+  * [WebSocket](5.2.%20Transport%20-%20Websocket.md)
+* [Events API](6.0.%20Event%20and%20tally%20rest%20api.md)
 * [Measurement units guidelines](7.0.%20Measurement%20units%20guidelines.md)

--- a/docs/2.0. Message types.md
+++ b/docs/2.0. Message types.md
@@ -9,58 +9,55 @@ Other sections can be accessed from the [Overview](1.0.%20Overview.md).
 ## 1. Introduction
 
 The main concern of the Event & Tally specification is to make possible for emitters to transmit their state changes to any interested consumer.
-A secondary concern is to give connected entities a mechanism by which to highlight issues in the linkage between them. In order to address this concern the `message_type` field will be added as a field in every single event message being sent.
+A secondary concern is to give connected entities a mechanism by which to highlight issues in the linkage between them. In order to address this concern the `message_type` field is included in every single event message being sent.
 
 These are the supported message types:
 
 * state
 * reboot
 * shutdown
-* connection_lost (only used by MQTT connections)
+* connection lost (only used by MQTT connections)
 * health (only used by WebSocket connections)
 
 For clarity, all MQTT message types are sent using the same MQTT topic defined through the transport parameter `broker_topic`.
 
 ### 1.1. The state message type
 
-The `state` message type will always be sent when the emitter changes state and issues a new event or in a response to a query state request to the [Event & Tally REST API](6.0.%20Event%20and%20tally%20rest%20api.md).  
+The `state` message type is always sent when the emitter changes state and issues a new event, and is also used in response to a REST API query for the state via the [Events API](6.0.%20Event%20and%20tally%20rest%20api.md).  
 These will be the predominant message types being sent in an Event & Tally system.
 
 The message structure shall have the following items:
 
-* identity [mandatory]
-* event_type [mandatory]
-* timing [mandatory with some optional fields]
-* payload [mandatory]
-* message_type [mandatory]
+* `identity` [mandatory]
+* `event_type` [mandatory]
+* `timing` [mandatory with some optional fields]
+* `payload` [mandatory]
+* `message_type` [mandatory]
 
 Message structure
 
 ```json
 {
-    "identity":
-    {
-        "source_id": "6cbd0441-7882-44cd-9557-842243a0d618",
-        "flow_id": "ff455cf3-fb17-448b-8f4c-e6c0e294f5ed"
-    },
-    "event_type": "boolean",
-    "timing":
-    {
-        "creation_timestamp": "1531680501:280709600",
-        "origin_timestamp": "1531680501:280401700",
-        "action_timestamp": "1531680501:320000000"
-    },
-    "payload":
-    {
-        "value": true
-    },
-    "message_type": "state"
+  "identity": {
+    "source_id": "6cbd0441-7882-44cd-9557-842243a0d618",
+    "flow_id": "ff455cf3-fb17-448b-8f4c-e6c0e294f5ed"
+  },
+  "event_type": "boolean",
+  "timing": {
+    "creation_timestamp": "1531680501:280709600",
+    "origin_timestamp": "1531680501:280401700",
+    "action_timestamp": "1531680501:320000000"
+  },
+  "payload": {
+    "value": true
+  },
+  "message_type": "state"
 }
 ```
 
-The `"creation_timestamp"` represents the timestamp at which an event has been created (for sensors this is the acquisition time). This field is mandatory.  
+The `"creation_timestamp"` represents the timestamp at which an event has been created (for sensors this is the acquisition time). This field is mandatory.
 
-The `"origin_timestamp"` represents the timestamp which led to the creation of an event due to external factors (a trigger). This field is optional.  
+The `"origin_timestamp"` represents the timestamp which led to the creation of an event due to external factors (a trigger). This field is optional.
 
 The `"action_timestamp"` represents the timestamp at which an event should be treated or result in an action (for synchronising and dealing with delays). This field is optional.
 
@@ -68,7 +65,7 @@ The `"action_timestamp"` is not intended to be associated with delays of more th
 
 The payload depends on the associated event_type (see [Event types](3.0.%20Event%20types.md)).
 
-The `flow_id` will _NOT_ be included in the response to a rest apy query state because the state is held by the source which has no dependency on a flow. It will, however, appear when being sent through one of the two specified transports because it will pass from the source through a flow and out on the network through the sender.
+The `flow_id` will _NOT_ be included in the response to a REST API query for the state via the Events API because the state is held by the source which has no dependency on a flow. It will, however, appear when being sent through one of the two specified transports because it will pass from the source through a flow and out on the network through the sender.
 
 ### 1.2. The reboot message type
 
@@ -76,19 +73,19 @@ The `reboot` message type will only be sent when the event emitter (source) is g
 
 The message structure shall have the following items:
 
-* identity [mandatory]
-* timing [mandatory]
-* message_type [mandatory]
+* `identity` [mandatory]
+* `timing` [mandatory]
+* `message_type` [mandatory]
 
 Message structure
 
 ```json
 {
-  "identity":{
+  "identity": {
     "source_id": "6cbd0441-7882-44cd-9557-842243a0d618",
     "flow_id": "ff455cf3-fb17-448b-8f4c-e6c0e294f5ed"
   },
-  "timing":{
+  "timing": {
     "creation_timestamp": "1531680501:280709600"
   },
   "message_type": "reboot"
@@ -97,25 +94,25 @@ Message structure
 
 The `"creation_timestamp"` represents the timestamp at which the emitter established that a `reboot` action will follow. This field is mandatory.
 
-### 1.3. The shutdown message
+### 1.3. The shutdown message type
 
-The `shutdown` message type will only be sent when the event emitter (sender) is going to experience a planned shutdown. This message will announce any connected consumers that the emitter will become unavailable. The recommendation for receivers is to park their subscription and update their IS-04 model in the registry.
+The `shutdown` message type will only be sent when the event emitter (sender) is going to experience a planned shutdown. This message will announce to any connected consumers that the emitter will become unavailable. The recommendation for receivers is to park their subscription and update their IS-04 model in the registry.
 
 The message structure shall have the following items:
 
-* identity [mandatory]
-* timing [mandatory]
-* message_type [mandatory]
+* `identity` [mandatory]
+* `timing` [mandatory]
+* `message_type` [mandatory]
 
 Message structure
 
 ```json
 {
-  "identity":{
+  "identity": {
     "source_id": "6cbd0441-7882-44cd-9557-842243a0d618",
     "flow_id": "ff455cf3-fb17-448b-8f4c-e6c0e294f5ed"
   },
-  "timing":{
+  "timing": {
     "creation_timestamp": "1531680501:280709600"
   },
   "message_type": "shutdown"
@@ -124,23 +121,23 @@ Message structure
 
 The `"creation_timestamp"` represents the timestamp at which the emitter established that a `shutdown` action will follow. This field is mandatory.
 
-### 1.4. The connection lost message
+### 1.4. The connection lost message type
 
-The `connection_lost` message is going to be sent by all emitters as an `MQTT WILL message` to the MQTT broker. This shall be done upon first connection to the broker.
-If the emitter ungracefully disconnects from the MQTT broker, the `connection_lost WILL` message will be sent by the broker to all consumers subscribed to its topic. Hence, the `connection_lost` message will only be used with MQTT connections.  
+The `connection_lost` message is sent by all emitters as an `MQTT WILL message` to the MQTT broker. This shall be done upon first connection to the broker.
+If the emitter ungracefully disconnects from the MQTT broker, the `connection_lost WILL` message will be sent by the broker to all consumers subscribed to its topic. Hence, the `connection_lost` message is only used with MQTT connections.
 
 The recommendation for receivers is to check for a fresh state (fresh in this context meaning more recent timestamps) after a user configurable amount of time, and if no state is received from the broker to park the subscription and update the IS-04 model in the registry.
 
 The message structure shall have the following items:
 
-* identity [mandatory]
-* message_type [mandatory]
+* `identity` [mandatory]
+* `message_type` [mandatory]
 
 Message structure
 
 ```json
 {
-  "identity":{
+  "identity": {
     "source_id": "6cbd0441-7882-44cd-9557-842243a0d618",
     "flow_id": "ff455cf3-fb17-448b-8f4c-e6c0e294f5ed"
   },
@@ -153,22 +150,22 @@ For more information about `MQTT WILL` messages consult the MQTT specification a
 * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/csprd02/mqtt-v3.1.1-csprd02.html
 * https://www.hivemq.com/blog/mqtt-essentials-part-9-last-will-and-testament
 
-### 1.5. The health message
+### 1.5. The health message type
 
-The `health` message will only be sent on a WebSocket connection as a response to a `health` command see [Websocket transport](5.2.%20Transport%20-%20Websocket.md).
+The `health` message will only be sent on a WebSocket connection as a response to a `health` command see [WebSocket transport](5.2.%20Transport%20-%20Websocket.md).
 
 The recommendation for receivers is to detect missing `health` responses (no `health` response is sent back within 5 seconds) and after a 12 seconds timeout (two consecutive missed `health` responses plus 2 seconds to allow for latencies) either attempt to reconnect to the WebSocket and re-initialise the subscriptions list or park the subscription and update the IS-04 model in the registry.
 
 The message structure shall have the following items:
 
-* timing [mandatory with some optional fields]
-* message_type [mandatory]
+* `timing` [mandatory with some optional fields]
+* `message_type` [mandatory]
 
 Message structure
 
 ```json
-{  
-  "timing":{
+{
+  "timing": {
     "origin_timestamp": "1441974485:12300000",
     "creation_timestamp": "1441974485:23400000"
   },
@@ -176,6 +173,6 @@ Message structure
 }
 ```
 
-The `"creation_timestamp"` represents the health timestamp introduced by the sender. This field is mandatory.  
+The `"creation_timestamp"` represents the health timestamp introduced by the sender. This field is mandatory.
 
-The `"origin_timestamp"` represents the original health timestamp sent by the receiver. This field is optional.  
+The `"origin_timestamp"` represents the original health timestamp sent by the receiver. This field is optional.

--- a/docs/3.0. Event types.md
+++ b/docs/3.0. Event types.md
@@ -96,15 +96,20 @@ _Type definition_:
 
 The *number* event type is identified as `"number"` in the NMOS source.
 
-In addition to the mandatory `value` field, an optional `scale` field is introduced to help carrying rational numbers without any loss of the precision. In that case the `value` field represents the _numerator_ and the `scale` field represents the _denominator_ of the fraction.
+In addition to the mandatory `value` field, an optional `scale` field is introduced to help carrying rational numbers without any loss of precision. In that case the `value` field represents the _numerator_ and the `scale` field represents the _denominator_ of the fraction.
 
 This event type is associated with a type definition object that is used to specify the following:
 
-* a `scale` field for representing rational numbers [optional] (default = 1)
+* a `scale` field indicating the denominator typically used for rational numbers in the event payload [optional]
 * minimum value [mandatory]
 * maximum value [mandatory]
 * step value [optional] (default = 1)
 * measurement unit [optional]
+
+The value of the optional `step` field indicates the precision.
+The value of `max - min` should be an integer multiple of `step` (taking account the `value` and `scale` of each).
+Similarly, for each event, `payload - min` should be an integer multiple of `step`.
+The `scale` field of `min`, `max`, `step`, and each event `payload`, are typically the same.
 
 Payload examples:
 

--- a/docs/3.0. Event types.md
+++ b/docs/3.0. Event types.md
@@ -16,7 +16,7 @@ These are the supported event types:
 * enum
 * object (out of scope for version 1.0 of this specification)
 
-The types are identified by the corresponding values in the event_type field in an event message and the NMOS source. When additional restrictions are applied to an event type, the *type definition object* will be provided using the Event & Tally REST API (see [Event & Tally REST API](6.0.%20Event%20and%20tally%20rest%20api.md)). The type definition object will always define the type of the `value` field and can define restrictions on the value.
+The types are identified by the corresponding values in the `event_type` field in an event message and the NMOS source. When additional restrictions are applied to an event type, the *type definition object* is provided using the Events API (see [Events API](6.0.%20Event%20and%20tally%20rest%20api.md)). The type definition object always defines the type of the `value` field and can define restrictions on the value.
 
 ## 2. Base types
 
@@ -24,7 +24,7 @@ The base type payloads always contain the `"value"` field and the type of the fi
 
 ### 2.1 boolean
 
-The *boolean* event type will be identified as `"boolean"` in the NMOS source.
+The *boolean* event type is identified as `"boolean"` in the NMOS source.
 
 #### _Example_:
 
@@ -59,9 +59,9 @@ _Type definition_:
 
 ### 2.2 string
 
-The *string* event type will be identified as `"string"` in the NMOS source.
+The *string* event type is identified as `"string"` in the NMOS source.
 
-The event type may be associated with a type definition object that may apply the following restrictions:
+This event type is associated with a type definition object that is used to specify the following:
 
 * minimum length [optional]
 * maximum length [optional]
@@ -94,17 +94,17 @@ _Type definition_:
 
 ### 2.3 number
 
-The *number* event type will be identified as `"number"` in the NMOS source.
+The *number* event type is identified as `"number"` in the NMOS source.
 
 In addition to the mandatory `value` field, an optional `scale` field is introduced to help carrying rational numbers without any loss of the precision. In that case the `value` field represents the _numerator_ and the `scale` field represents the _denominator_ of the fraction.
 
-The event type may be associated with a type definition object that may apply the following restrictions:
+This event type is associated with a type definition object that is used to specify the following:
 
-* indicate an optional `scale` field for representing rational numbers [optional] (default = 1)
-* indicate minimum value [mandatory]
-* indicate maximum value [mandatory]
-* indicate step value [optional] (default = 1)
-* indicate the measurement unit [optional]
+* a `scale` field for representing rational numbers [optional] (default = 1)
+* minimum value [mandatory]
+* maximum value [mandatory]
+* step value [optional] (default = 1)
+* measurement unit [optional]
 
 Payload examples:
 
@@ -139,7 +139,7 @@ _Type definition_:
 
 ### 2.3.1 measurements
 
-In the case where a unit of measure is specified for the number type, the event type will be identified as `"number/{Name}/{Unit}"` in the NMOS source, where `Name` is the name of the measurement and `Unit` is the measurement unit, for example: `"number/temperature/C"`.
+In the case where a unit of measure is specified for the number type, the event type is identified as `"number/{Name}/{Unit}"` in the NMOS source, where `Name` is the name of the measurement and `Unit` is the measurement unit, for example: `"number/Temperature/C"`.
 
 The definition of the units of measure is out of scope of this specification but the SI system of units is highly recommended.
 
@@ -150,7 +150,7 @@ The recommended strategy for naming measurement units can be read in the [Measur
 Temperature sensor with precision of 0.1°C
 
 _Event Type_:
-`number/temperature/C`
+`number/Temperature/C`
 
 _Payload_:
 
@@ -189,7 +189,7 @@ _Type definition_:
   },
   "step": {
     "value": 1,
-    "scale":10
+    "scale": 10
   },
   "unit": "C"
 }
@@ -240,12 +240,12 @@ _Type definition_:
 
 Enums can be defined on top of any of the three base types and provide both the list of allowed values and metadata that describe those values.
 
-The *enum* event type has to be associated with a type definition object that has to provide the following:
+This event type is associated with a type definition object that is used to specify the following:
 
 * a label for all the possible value options [mandatory]
 * a description for all possible value options [mandatory]
 
-The `enum` event type will be identified as `"{BaseType}/enum/{Name}"` in the NMOS source, where `Name` is the name of the enum.
+The `enum` event type is identified as `"{BaseType}/enum/{Name}"` in the NMOS source, where `Name` is the name of the enum.
 
 #### _Example_:
 A numerical enum exposing the current studio usage and defining the button labels and description of the states.
@@ -265,8 +265,8 @@ _Type definition_:
 
 ```json
 {
-  "type" :  "number",
-  "values" : [
+  "type":  "number",
+  "values": [
     {
       "value": 0,
       "label": "idle",
@@ -305,8 +305,8 @@ _Type definition_:
 
 ```json
 {
-  "type" :  "boolean",
-  "values" : [
+  "type": "boolean",
+  "values": [
     {
       "value": false,
       "label": "OFF",
@@ -340,8 +340,8 @@ _Type definition_:
 
 ```json
 {
-  "type" :  "string",
-  "values" : [
+  "type": "string",
+  "values": [
     {
       "value": "unknown",
       "label": "Device state is unknown",
@@ -368,15 +368,15 @@ _Type definition_:
 
 ## 4. object (out of scope for version 1.0 of this specification)
 
-_The usage of the `object` event type is out of scope of this specification for version 1.0_
+_The usage of the `object` event type is out of scope of this specification for version 1.0._
 
-The *object* event type has to be associated with a type definition object that has to provide the object structure. It will consist of fields that can have following types:
+This event type will be associated with a type definition object that is used to specify the object structure. It will consist of fields that can have following types:
 
 * other base types (boolean, number, string, enum)
 * other objects
 * arrays of other base types or objects
 
-This definition file will describe the payload types and metadata associated in detail. The available metadata for each base type will be identical to the metadata defined for standalone types.
+This definition will describe the payload types and metadata associated in detail. The available metadata for each base type will be identical to the metadata defined for standalone types.
 
 The `object` event type will be identified as `"object/{Name}"` in the NMOS source, where `Name` is the name of the object.
 
@@ -386,7 +386,7 @@ Sources `"event_type"` field always needs to have an exact specific event type (
 
 Receivers `"event_types"` field can have a specific event type or may have a derived partial event type using a wildcard (`*`).
 
-A wildcard (`*`) must replace a whole word and can only be used at the end of an event_type definition.
+A wildcard (`*`) must replace a whole word and can only be used at the end of an event type definition.
 
 More details about NMOS resources in the section [Core models](4.0.%20Core%20models.md).
 

--- a/docs/4.0. Core models.md
+++ b/docs/4.0. Core models.md
@@ -11,7 +11,7 @@ Other sections can be accessed from the [Overview](1.0.%20Overview.md).
 The following transports are supported:
 
 * [MQTT](5.1.%20Transport%20-%20MQTT.md)
-* [Websocket](5.2.%20Transport%20-%20Websocket.md)
+* [WebSocket](5.2.%20Transport%20-%20Websocket.md)
 
 The v1.0 specification relies on the following existing specifications:
 
@@ -74,8 +74,8 @@ Example:
 
 The supported transports have been extended to include:
 
-* urn:x-nmos:transport:mqtt
-* urn:x-nmos:transport:websocket
+* `urn:x-nmos:transport:mqtt`
+* `urn:x-nmos:transport:websocket`
 
 Example:
 
@@ -107,8 +107,8 @@ Event receivers use the `urn:x-nmos:format:data` format.
 
 The supported transports have been extended to include:
 
-* urn:x-nmos:transport:mqtt
-* urn:x-nmos:transport:websocket
+* `urn:x-nmos:transport:mqtt`
+* `urn:x-nmos:transport:websocket`
 
 Example:
 
@@ -139,7 +139,7 @@ Example:
 
 ## 3. NMOS Parameter Registers highlights
 
-Event devices have an additional control in the `controls` array for the Event & Tally REST API (see [Event & Tally REST API](6.0.%20Event%20and%20tally%20rest%20api.md)).
+Event devices have an additional control in the `controls` array for the Events API (see [Events API](6.0.%20Event%20and%20tally%20rest%20api.md)).
 
 The definition for this control is detailed with an entry in the NMOS Parameter Registers.
 
@@ -149,20 +149,20 @@ The definition for this control is detailed with an entry in the NMOS Parameter 
 
 The following transport parameters are exposed:
 
-* destination_host (MQTT broker hostname or IP - defined in the IS-05 specification)
-* destination_port (MQTT broker port - defined in the IS-05 specification)
-* broker_topic (MQTT topic - defined in the IS-05 specification)
-* ext_is_07_rest_api_url (the event and tally rest api url targeting the associated source - defined in the IS-07 specification)
+* `destination_host` (MQTT broker hostname or IP - defined in the IS-05 specification)
+* `destination_port` (MQTT broker port - defined in the IS-05 specification)
+* `broker_topic` (MQTT topic - defined in the IS-05 specification)
+* `ext_is_07_rest_api_url` (the URL of the Events API resource for the associated source - defined in the IS-07 specification)
 
 `ext_is_07_rest_api_url` schemas and examples are defined in IS-07 following the IS-05 templates.
 
-### 4.2. Websocket sender transport parameters
+### 4.2. WebSocket sender transport parameters
 
 The following transport parameters are exposed:
 
-* connection_uri (The websocket server uri - defined in the IS-05 specification)
-* ext_is_07_rest_api_url (the event and tally rest api url targeting the associated source - defined in the IS-07 specification)
-* ext_is_07_source_id (the event source id used for filtering subscriptions - defined in the IS-07 specification)
+* `connection_uri` (the WebSocket server URI - defined in the IS-05 specification)
+* `ext_is_07_rest_api_url` (the URL of the Events API resource for the associated source - defined in the IS-07 specification)
+* `ext_is_07_source_id` (the event source id used for filtering subscriptions - defined in the IS-07 specification)
 
 `ext_is_07_rest_api_url` schemas and examples are defined in IS-07 following the IS-05 templates.
 `ext_is_07_source_id` schemas and examples are defined in IS-07 following the IS-05 templates.
@@ -171,20 +171,20 @@ The following transport parameters are exposed:
 
 The following transport parameters are exposed:
 
-* source_host (MQTT broker hostname or IP - defined in the IS-05 specification)
-* source_port (MQTT broker port - defined in the IS-05 specification)
-* broker_topic (MQTT topic - defined in the IS-05 specification)
-* ext_is_07_rest_api_url (the event and tally rest api url targeting the associated source - defined in the IS-07 specification)
+* `source_host` (MQTT broker hostname or IP - defined in the IS-05 specification)
+* `source_port` (MQTT broker port - defined in the IS-05 specification)
+* `broker_topic` (MQTT topic - defined in the IS-05 specification)
+* `ext_is_07_rest_api_url` (the URL of the Events API resource for the associated source - defined in the IS-07 specification)
 
 `ext_is_07_rest_api_url` schemas and examples are defined in IS-07 following the IS-05 templates.
 
-### 4.4. Websocket receiver transport parameters
+### 4.4. WebSocket receiver transport parameters
 
 The following transport parameters are exposed:
 
-* connection_uri (The websocket server uri - defined in the IS-05 specification)
-* ext_is_07_rest_api_url (the event and tally rest api url targeting the associated source - defined in the IS-07 specification)
-* ext_is_07_source_id (the event source id used for filtering subscriptions - defined in the IS-07 specification)
+* `connection_uri` (the WebSocket server URI - defined in the IS-05 specification)
+* `ext_is_07_rest_api_url` (the URL of the Events API resource for the associated source - defined in the IS-07 specification)
+* `ext_is_07_source_id` (the event source id used for filtering subscriptions - defined in the IS-07 specification)
 
 `ext_is_07_rest_api_url` schemas and examples are defined in IS-07 following the IS-05 templates.
 `ext_is_07_source_id` schemas and examples are defined in IS-07 following the IS-05 templates.
@@ -195,18 +195,18 @@ All of the `ext_` transport parameters mentioned in the previous sections follow
 
 #### ext_is_07_rest_api_url
 
-The `ext_is_07_rest_api_url` parameter represents the url to the API path which offers the current state and type of an event emitter (source) (see [Event & Tally REST API](6.0.%20Event%20and%20tally%20rest%20api.md))
+The `ext_is_07_rest_api_url` parameter represents the URL to the Events API resource which offers the current state and type of an event emitter (source) (see [Events API](6.0.%20Event%20and%20tally%20rest%20api.md))
 
 It is important for the sender to always populate the `ext_is_07_rest_api_url` field using the following template:  
-`{is_04_control_base_url}`sources/`{source_id_associated_with_sender}`/
-The sender will populate `is_05_control_base_url` as being the href offered by the `urn:x-nmos:control:events/v1.0` control in the controls array of the sender device.  
+`{is_04_control_base_url}sources/{source_id_associated_with_sender}/`
+The sender will populate `is_04_control_base_url` as being the `href` offered by the `urn:x-nmos:control:events/v1.0` control in the controls array of the sender device.  
 The sender will populate `source_id_associated_with_sender` as being the unique ID of the source associated with the sender.  
-For consistency the `ext_is_07_rest_api_url` url offered will always end with a trailing slash.
+For consistency the `ext_is_07_rest_api_url` URL offered will always end with a trailing slash.
 
 A receiver should always expect the `ext_is_07_rest_api_url` to follow the format above and only needs to append one of the following suffixes:
 
-* state (to retrieve the current state of the emitter)
-* type (to retrieve the metadata associated with the event_type of the emitter)
+* `state` (to retrieve the current state of the emitter)
+* `type` (to retrieve the metadata associated with the event_type of the emitter)
 
 #### ext_is_07_source_id
 
@@ -216,11 +216,11 @@ The `ext_is_07_source_id` transport parameter represents the source id which is 
 
 Event and tally connection management only supports IS-05 connection management (the legacy IS-04 connection management is not supported and deprecated).
 
-This specification defines four new transport parameters to be used in a `PATCH` request:
+This specification defines four new transport parameters to be used in a PATCH request:
 
 * `broker_topic`
 * `connection_uri`
 * `ext_is_07_rest_api_url`
 * `ext_is_07_source_id`
 
-The usage will be detailed in each [transport](5.0.%20Transports.md) section and in the [Event & Tally REST API](6.0.%20Event%20and%20tally%20rest%20api.md) section.
+The usage is detailed in each [transport](5.0.%20Transports.md) section and in the [Events API](6.0.%20Event%20and%20tally%20rest%20api.md) section.

--- a/docs/5.0. Transports.md
+++ b/docs/5.0. Transports.md
@@ -12,4 +12,4 @@ Other sections can be accessed from the [Overview](1.0.%20Overview.md).
 Mandatory supported transports:
 
 * [MQTT](5.1.%20Transport%20-%20MQTT.md)
-* [Websocket](5.2.%20Transport%20-%20Websocket.md)
+* [WebSocket](5.2.%20Transport%20-%20Websocket.md)

--- a/docs/5.1. Transport - MQTT.md
+++ b/docs/5.1. Transport - MQTT.md
@@ -51,7 +51,7 @@ Example of IS-05 PATCH request:
 }
 ```
 
-### Disconnecting/Parking
+### 3.3 Disconnecting/Parking
 
 A disconnection IS-05 PATCH request should always trigger the receiver to unsubscribe from the associated `broker_topic`.
 

--- a/docs/5.1. Transport - MQTT.md
+++ b/docs/5.1. Transport - MQTT.md
@@ -22,17 +22,17 @@ NMOS resources using MQTT will use the `urn:x-nmos:transport:mqtt` transport.
 
 ## 3. Connection management
 
-Only IS-05 connection management will be used for connection management of resources defined in this specification.
+Only IS-05 connection management is to be used for connection management of resources defined in this specification.
 
 ### 3.1 broker_topic
 
-The `broker_topic` parameter will hold the MQTT topic and will always be set to the source id, prefixed with `x-nmos/source/` for easier filtering.
+The `broker_topic` parameter holds the MQTT topic and will always be set to the source id, prefixed with `x-nmos/source/` for easier filtering.
 
 ### 3.2 ext_is_07_rest_api_url
 
-The `ext_is_07_rest_api_url` parameter will represent the url to the API path which offers the current state and type of an event emitter (source) (see [Event & Tally REST API](6.0.%20Event%20and%20tally%20rest%20api.md))
+The `ext_is_07_rest_api_url` parameter represents the URL to the Events API resource which offers the current state and type of an event emitter (source) (see [Events API](6.0.%20Event%20and%20tally%20rest%20api.md))
 
-_Example of IS-05 PATCH request_
+Example of IS-05 PATCH request:
 
 ```json
 {
@@ -53,22 +53,22 @@ _Example of IS-05 PATCH request_
 
 ### Disconnecting/Parking
 
-A disconnection IS-05 `patch` request should always trigger the receiver to unsubscribe from the associated `broker_topic`.
+A disconnection IS-05 PATCH request should always trigger the receiver to unsubscribe from the associated `broker_topic`.
 
-## 4. QOS Settings
+## 4. QoS Settings
 
-MQTT publishers are recommended to use the `exactly once QOS (2)`
+MQTT publishers are recommended to use the QoS (Quality of Service) level `exactly once (2)`.
 
 ## 5. Late joiners
 
 MQTT publishers are required to send the `retained message` flag with every message in order to solve the problem of late joiners.
 
-Consumers (receivers) have a choice to either use the retained message or query the late joiners api using `ext_is_07_rest_api_url` to access the latest state of an emitter in order to get in sync.
+Consumers (receivers) have a choice to either use the retained message or query the late joiners API using `ext_is_07_rest_api_url` to access the latest state of an emitter in order to get in sync.
 
 ## 6. MQTT _WILL_ message
 
 All event emitters (MQTT publishers) should send an `MQTT WILL` message upon first connection to the MQTT broker.
-This should be the `connection_lost` message described in `1.4 The connection lost message` under [Message types](2.0.%20Message%20types.md).
+This should be the `connection_lost` message described in [Message types - The connection lost message type](2.0.%20Message%20types.md#14-the-connection-lost-message-type).
 
 ## 7. Broker discovery
 

--- a/docs/5.2. Transport - Websocket.md
+++ b/docs/5.2. Transport - Websocket.md
@@ -39,7 +39,7 @@ Filtering is achieved using the subscription mechanism explained in the followin
 
 The `ext_is_07_rest_api_url` transport parameter represents the URL to the Events API resource which offers the current state and type of an event emitter (source) (see [Events API](6.0.%20Event%20and%20tally%20rest%20api.md))
 
-## 3.3 ext_is_07_source_id
+### 3.3 ext_is_07_source_id
 
 The `ext_is_07_source_id` transport parameter represents the source id which is the emitter of the event. This is required for the WebSocket client to be able to build the subscriptions required from the server. Furthermore, the source id is required to filter and help the client determine which of the connected receivers needs to be notified when an event is consumed.
 
@@ -63,9 +63,9 @@ Example of IS-05 PATCH request:
 }
 ```
 
-There is no mandated URL base path for servers to use for ``connection_uri``. The value above, `/x-nmos/events/v1.0/devices/{deviceId}`, is an example.
+There is no mandated URL base path for servers to use for `connection_uri`. The value above, `/x-nmos/events/v1.0/devices/{deviceId}`, is an example.
 
-### Disconnecting/Parking
+### 3.5 Disconnecting/Parking
 
 A disconnection IS-05 PATCH request should always trigger the client to remove the associated source id from the current WebSocket subscription list.
 If the source is the last item in the subscription list, then it is recommended for the client to close the underlying WebSocket connection.

--- a/docs/5.2. Transport - Websocket.md
+++ b/docs/5.2. Transport - Websocket.md
@@ -1,4 +1,4 @@
-# Websocket Transport
+# WebSocket Transport
 
 _(c) AMWA 2018, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
@@ -18,13 +18,13 @@ Other sections can be accessed from the [Overview](1.0.%20Overview.md).
 The NMOS Events & Tally community has shown interest in using the WebSocket protocol as a transport for events and tally information as it is a familiar protocol which has already been used in the NMOS ecosystem.
 There is an ongoing debate about WebSocket topologies being less efficient than broker based transport topologies like MQTT in a large-scale system because each sending device needs to host its own server to cope with demand. One of the cases we have identified which could be improved is when a device hosts multiple receivers which are interested in multiple senders on another device. In a simple receiver to sender connection mapping a connection would be required from each receiver to each sender. This could be improved with a device subscriptions model whereby you would only have a single connection between the devices with a subscriptions list.
 
-![Websocket events subscription model](images/websocket-events-subscription-model.png)
+![WebSocket events subscription model](images/websocket-events-subscription-model.png)
 
-With that in mind, going forward you will see concepts such as server and client which represent the senders’ collection and the interested receivers’ collection. Furthermore, even though there will only be a single websocket url hosted by the sender device each client will have its own communication channel with the server with unique subscriptions.
+With that in mind, going forward you will see concepts such as server and client which represent the senders’ collection and the interested receivers’ collection. Furthermore, even though there will only be a single WebSocket URL for the sender, each client will have its own two-way communication channel (WebSocket connection) with the server with unique subscriptions.
 
-## 2. Websocket server uri
+## 2. NMOS Resources transport
 
-The Websocket server will be hosted under an NMOS sender device. The uri will be exposed in the `connection_uri` transport parameter by the IS-05 v1.1 compliant sender.
+NMOS resources using WebSocket will use the `urn:x-nmos:transport:websocket` transport.
 
 ## 3. Connection management
 
@@ -32,18 +32,18 @@ Only IS-05 connection management will be used for connection management of resou
 
 ### 3.1 connection_uri
 
-The `connection_uri` parameter will be the url of the websocket server. All senders on one NMOS device should offer the same `connection_uri` to allow the number of websocket connections needed to be reduced. It may be appropriate for the same `connection_uri` to be offered for the senders of all devices on a node.
-Filtering will be achieved using the subscription mechanism explained in the following sections.
+The `connection_uri` transport parameter of the IS-05 v1.1 compliant sender is the URL of the associated WebSocket server. All senders on one NMOS device should offer the same `connection_uri` to allow the number of WebSocket connections needed to be reduced. It may be appropriate for the same `connection_uri` to be offered for the senders of all devices on a node.
+Filtering is achieved using the subscription mechanism explained in the following sections.
 
 ### 3.2 ext_is_07_rest_api_url
 
-The `ext_is_07_rest_api_url` parameter will represent the url to the API path which offers the current state and type of an event emitter (source) (see [Event & Tally REST API](6.0.%20Event%20and%20tally%20rest%20api.md))
+The `ext_is_07_rest_api_url` transport parameter represents the URL to the Events API resource which offers the current state and type of an event emitter (source) (see [Events API](6.0.%20Event%20and%20tally%20rest%20api.md))
 
 ## 3.3 ext_is_07_source_id
 
-The `ext_is_07_source_id` transport parameter represents the source id which is the emitter of the event. This is required for the websocket client to be able to build the subscriptions required from the server. Furthermore, the source id is required to filter and help the client determine which of the connected receivers needs to be notified when an event is consumed.
+The `ext_is_07_source_id` transport parameter represents the source id which is the emitter of the event. This is required for the WebSocket client to be able to build the subscriptions required from the server. Furthermore, the source id is required to filter and help the client determine which of the connected receivers needs to be notified when an event is consumed.
 
-_Example of IS-05 PATCH request_
+Example of IS-05 PATCH request:
 
 ```json
 {
@@ -63,30 +63,31 @@ _Example of IS-05 PATCH request_
 }
 ```
 
-There is no mandated URL base path for servers to use for `connection_uri`. The value above, `/x-nmos/events/v1.0/devices/{deviceId}`, is an example.
+There is no mandated URL base path for servers to use for ``connection_uri``. The value above, `/x-nmos/events/v1.0/devices/{deviceId}`, is an example.
 
 ### Disconnecting/Parking
 
-A disconnection IS-05 `patch` request should always trigger the client to remove the associated `source id` from the current websocket subscription list.
-If the source is the last item in the subscription list, then it is recommended for the client to close the underlying websocket connection.
+A disconnection IS-05 PATCH request should always trigger the client to remove the associated source id from the current WebSocket subscription list.
+If the source is the last item in the subscription list, then it is recommended for the client to close the underlying WebSocket connection.
 
 ## 4. Subscriptions strategy
 
-Upon connection, a client needs to initialise its subscription list by sending a subscription command on the WebSocket channel.
+Upon connection, a client needs to initialise its subscription list by sending a `subscription` command on the WebSocket connection.
 
 After establishing the subscription list, the client will start receiving events only for the items it has subscribed to.
 A client may choose to add or remove items to its subscription at any point in time.
 
-Each time a client updates its subscriptions list (sends a new subscription command), the server will resend all the current states for each of the subscribed sources. If a client needs to reconnect, then the WebSocket session context needs to be re-established so the client will send a new subscription command re-initialising its subscription.
+Each time a client updates its subscriptions list (sends a new `subscription` command), the server will resend all the current states for each of the subscribed sources. If a client needs to reconnect, then the WebSocket connection context needs to be re-established so the client must send a new `subscription` command re-initialising its subscription.
 
-A subscription command will only get sent out as a consequence of an NMOS Connection Management action or a reconnection.
+A `subscription` command is only sent as a consequence of an NMOS Connection Management action or a reconnection.
 
 ### 4.1 Heartbeats
 
-Upon connection, the client is required to report its health every 5 seconds in order to maintain its session and subscription. This is similar to the behaviour required by the registry for nodes in IS-04 specification. Every `health` command should be followed by a `health` response (see [Message types](2.0.%20Message%20types.md)).  
-The server is expected to check `health` commands and after a 12 seconds timeout (2 consecutive missed `health` commands plus 2 seconds to allow for latencies) it should clear the subscriptions for that particular client and close the websocket connection. The server is also required to respond to a heartbeat within 5 seconds of receiving the `health` command.
+Upon connection, the client is required to report its health every 5 seconds in order to maintain its connection and subscription. This is similar to the behaviour required by the registry for nodes in IS-04 specification. Every `health` command should be followed by a `health` response (see [Message types](2.0.%20Message%20types.md)).
 
-Example health command
+The server is expected to check `health` commands and after a 12 seconds timeout (2 consecutive missed `health` commands plus 2 seconds to allow for latencies) it should clear the subscriptions for that particular client and close the WebSocket connection. The server is also required to respond to a heartbeat within 5 seconds of receiving the `health` command.
+
+Example `health` command:
 
 ```json
 {
@@ -95,11 +96,11 @@ Example health command
 }
 ```
 
-Example health response
+Example `health` response:
 
 ```json
-{  
-  "timing":{
+{
+  "timing": {
     "origin_timestamp": "1441974485:12300000",
     "creation_timestamp": "1441974485:23400000"
   },
@@ -111,13 +112,13 @@ Example health response
 
 #### Step 1
 
-The client connects to the `websocket_href` websocket session.
+The client connects to the `connection_uri` WebSocket server URL.
 
 #### Step 2
 
 The client establishes a subscriptions list by sending a `subscription` command.
 
-Example
+Example:
 
 ```json
 {
@@ -139,10 +140,10 @@ The client continues to receive events only from the subscribed sources.
 
 #### Step 5
 
-The client issues health commands every 5 seconds as described above.
+The client issues `health` commands every 5 seconds as described above.
 
 ## 5. Late joiners
 
 As described above a client will receive the initial states for all the sources in its subscription list.
 
-A client may also choose to query the Event & Tally REST API using `ext_is_07_rest_api_url` to access the latest state of an emitter in order to verify the current state.
+A client may also choose to query the Events API using `ext_is_07_rest_api_url` to access the latest state of an emitter in order to verify the current state.

--- a/docs/6.0. Event and tally rest api.md
+++ b/docs/6.0. Event and tally rest api.md
@@ -1,22 +1,22 @@
-# Event & Tally REST API
+# Events API
 
 _(c) AMWA 2018, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
-This document describes the use of the Event & Tally REST API.
+This document describes the use of the Events API.
 
 Other sections can be accessed from the [Overview](1.0.%20Overview.md).
 
 ## 1. Introduction
 
-The late joiners API is meant as a protocol agnostic means by which a consumer (receiver) can get in sync with the last known state of an event emitter. The API *has to be* used only together with other event based transports to minimize the load on the device allowing for better scalability. The main purpose of the API is resolving the problem of late joiners but it can be also used for low-frequency sanity checks of the states for signals that change states very rarely.
+The Events API is meant as a protocol-agnostic means by which a consumer (receiver) can get in sync with the last known state of an event emitter. The API *has to be* used only together with other event-based transports to minimize the load on the device allowing for better scalability. The main purpose of the API is resolving the problem of late joiners but it can be also used for low-frequency sanity checks of the states for signals that change states very rarely.
 The API also allows for a consumer to find the type definition associated with a source event type.
 
 ## 2. NMOS Resource
 
-The API will be hosted under an NMOS device in the `controls` array using the `urn:x-nmos:control:events` type.
-For consistency the `href` url offered will always end with a trailing slash.
+The Events API should be advertised as a 'control' endpoint under an IS-04 NMOS device in the `controls` array using the `urn:x-nmos:control:events` type.
+For consistency the `href` URL offered will always end with a trailing slash.
 
-Example
+Example:
 
 ```json
 {
@@ -50,7 +50,7 @@ Example
 
 ## 3. Usage
 
-The api base will return the following path upon a successful Get request:
+The API base will return the following upon a successful GET request:
 
 ```json
 [
@@ -58,7 +58,7 @@ The api base will return the following path upon a successful Get request:
 ]
 ```
 
-The api `sources/id` path will return the following upon a successful Get request
+The API `sources/{sourceId}` resource will return the following upon a successful GET request
 
 ```json
 [
@@ -67,14 +67,14 @@ The api `sources/id` path will return the following upon a successful Get reques
 ]
 ```
 
-The `state` path allows for consumers to retrieve the latest state of the source whereas the `type` path allows for the retrieval
-of the type definition associated with the event type of the source.
+The `state` resource allows for consumers to retrieve the latest state of the source whereas the `type` resource allows for the retrieval
+of the *type definition object* associated with the event type of the source.
 
 Example of retrieving the `state` of a source:
 
 `GET http://hostname/x-nmos/events/v1.0/sources/a65c15a4-a52e-4960-8cd2-e05c31196e5f/state`
 
-Example response:  
+Example response:
 
 ```json
 {
@@ -97,7 +97,7 @@ Example of retrieving the `type` definition for a source:
 
 `GET http://hostname/x-nmos/events/v1.0/sources/a65c15a4-a52e-4960-8cd2-e05c31196e5f/type`
 
-Example response:  
+Example response:
 
 ```json
 {
@@ -107,7 +107,7 @@ Example response:
 
 ## 4. Type definition changes
 
-The `type` definitions are deemed as static in version 1.0 of this specification. This means the `type` definition may not change throughout the event life cycle.
+The `type` definitions are deemed as static in version 1.0 of this specification. This means the `type` definition must not change throughout the event life cycle.
 
 ## 5. Cases to avoid
 
@@ -134,7 +134,7 @@ To ensure compatibility, the response 'Access-Control-Allow-Headers' could be se
 
 For consistency and in order to adhere to how these APIs are specified in RAML, the 'primary' path for every resource has the trailing slash omitted.
 
-For example, an `ext_is_07_rest_api_url` set to `http://hostname/x-nmos/events/v1.0/` will have the following paths which _CAN NOT_ lead in a trailing slash:
+For example, an `ext_is_07_rest_api_url` set to `http://hostname/x-nmos/events/v1.0/` will have the following resource paths which _DO NOT_ have a trailing slash:
 
 * `http://hostname/x-nmos/events/v1.0/sources`
 * `http://hostname/x-nmos/events/v1.0/sources/a65c15a4-a52e-4960-8cd2-e05c31196e5f`


### PR DESCRIPTION
Proposed clarification of the relationship between 'scale', 'min', 'max', 'step' and the event payload for the "number" type.

This PR is on top of PR #44, so only commit 726f706df90311f1a3d7803f1a4cc01f42dab85d is interesting.

The changes are based on the discussion in #31, slightly repurposing `"scale"` in type_number.json rather than removing it (which is problematic in NMOS specs without a _major_ version bump, and I don't think we're ready for Event & Tally v2.0!).

