### PR TITLE
Updated proposal for IS-07 inclusion in IS-04

### DIFF
--- a/docs/4.0. Core models.md
+++ b/docs/4.0. Core models.md
@@ -51,7 +51,7 @@ Example:
 
 ### 2.2 Flows
 
-EVent flows also have a new `event_type` field.
+Event flows also have a new `event_type` field.
 Event flows use the `urn:x-nmos:format:data` format and have the media type set to `application/json`.
 
 Example:

--- a/docs/4.0. Core models.md
+++ b/docs/4.0. Core models.md
@@ -51,6 +51,7 @@ Example:
 
 ### 2.2 Flows
 
+EVent flows also have a new `event_type` field.
 Event flows use the `urn:x-nmos:format:data` format and have the media type set to `application/json`.
 
 Example:
@@ -66,6 +67,7 @@ Example:
     "source_id": "7b9d4864-5d6d-4227-a81d-8dd3e13e99b3",
     "version": "1529676926:000000000",
     "media_type": "application/json",
+    "event_type": "boolean",
     "device_id": "58f6b536-ca4c-43fd-880a-9df2501fc125"
 }
 ```
@@ -105,7 +107,7 @@ Example:
 ### 2.4. Receivers
 
 Event receivers have a new array called `event_types` inside the `caps` field in order to list all of the event types they can consume (more details in [Event types](3.0.%20Event%20types.md)).  
-Event receivers use the `urn:x-nmos:format:data` format.
+Event receivers use the `urn:x-nmos:format:data` format and if the `media_types` array is present inside the `caps` field, it must include `application/json`.
 
 The supported transports have been extended to include:
 
@@ -118,6 +120,9 @@ Example:
 {
     "tags": {},
     "caps": {
+        "media_types": [
+            "application/json"
+        ],
         "event_types": [
             "boolean"
         ]


### PR DESCRIPTION
Update as per https://github.com/AMWA-TV/nmos-discovery-registration/pull/100.

Main changes in that PR are to add "event_type" in Flow as well as Source.

> * Ensures all IS-07 data can be observed at the Flow level to avoid confusion between IS-07 and ST.291 at the Source level. The Source level is instead reserved for additional signalling of commonality between the Flows which sit under it.