### PR TITLE
Add api_proto TXT record to DNS-SD _nmos-mqtt._tcp advertisement

### DIFF
--- a/docs/4.0. Core models.md
+++ b/docs/4.0. Core models.md
@@ -149,44 +149,62 @@ The definition for this control is detailed with an entry in the NMOS Parameter 
 
 ### 4.1. MQTT sender transport parameters
 
-The following transport parameters are exposed:
+The following transport parameters are exposed (as defined for the MQTT transport in the IS-05 specification):
 
-* `destination_host` (MQTT broker hostname or IP - defined in the IS-05 specification)
-* `destination_port` (MQTT broker port - defined in the IS-05 specification)
-* `broker_topic` (MQTT topic - defined in the IS-05 specification)
-* `ext_is_07_rest_api_url` (the URL of the Events API resource for the associated source - defined in the IS-07 specification)
+* `destination_host`
+* `destination_port`
+* `broker_topic`
+* `broker_protocol`
+* `broker_authorization`
+
+In addition, this specification defines the following additional parameter:
+
+* `ext_is_07_rest_api_url` (the URL of the Events API resource for the associated source)
 
 `ext_is_07_rest_api_url` schemas and examples are defined in IS-07 following the IS-05 templates.
 
 ### 4.2. WebSocket sender transport parameters
 
-The following transport parameters are exposed:
+The following transport parameters are exposed (as defined for the WebSocket transport in the IS-05 specification):
 
-* `connection_uri` (the WebSocket server URI - defined in the IS-05 specification)
-* `ext_is_07_rest_api_url` (the URL of the Events API resource for the associated source - defined in the IS-07 specification)
-* `ext_is_07_source_id` (the event source id used for filtering subscriptions - defined in the IS-07 specification)
+* `connection_uri`
+* `connection_authorization`
+
+In addition, this specification defines the following additional parameters:
+
+* `ext_is_07_rest_api_url` (the URL of the Events API resource for the associated source)
+* `ext_is_07_source_id` (the event source id used for filtering subscriptions)
 
 `ext_is_07_rest_api_url` schemas and examples are defined in IS-07 following the IS-05 templates.
 `ext_is_07_source_id` schemas and examples are defined in IS-07 following the IS-05 templates.
 
 ### 4.3. MQTT receiver transport parameters
 
-The following transport parameters are exposed:
+The following transport parameters are exposed (as defined for the MQTT transport in the IS-05 specification):
 
-* `source_host` (MQTT broker hostname or IP - defined in the IS-05 specification)
-* `source_port` (MQTT broker port - defined in the IS-05 specification)
-* `broker_topic` (MQTT topic - defined in the IS-05 specification)
-* `ext_is_07_rest_api_url` (the URL of the Events API resource for the associated source - defined in the IS-07 specification)
+* `source_host`
+* `source_port`
+* `broker_topic`
+* `broker_protocol`
+* `broker_authorization`
+
+In addition, this specification defines the following additional parameter:
+
+* `ext_is_07_rest_api_url` (the URL of the Events API resource for the associated source)
 
 `ext_is_07_rest_api_url` schemas and examples are defined in IS-07 following the IS-05 templates.
 
 ### 4.4. WebSocket receiver transport parameters
 
-The following transport parameters are exposed:
+The following transport parameters are exposed (as defined for the WebSocket transport in the IS-05 specification):
 
-* `connection_uri` (the WebSocket server URI - defined in the IS-05 specification)
-* `ext_is_07_rest_api_url` (the URL of the Events API resource for the associated source - defined in the IS-07 specification)
-* `ext_is_07_source_id` (the event source id used for filtering subscriptions - defined in the IS-07 specification)
+* `connection_uri`
+* `connection_authorization`
+
+In addition, this specification defines the following additional parameters:
+
+* `ext_is_07_rest_api_url` (the URL of the Events API resource for the associated source)
+* `ext_is_07_source_id` (the event source id used for filtering subscriptions)
 
 `ext_is_07_rest_api_url` schemas and examples are defined in IS-07 following the IS-05 templates.
 `ext_is_07_source_id` schemas and examples are defined in IS-07 following the IS-05 templates.
@@ -218,10 +236,8 @@ The `ext_is_07_source_id` transport parameter represents the source id which is 
 
 Event & Tally connection management only supports IS-05 connection management (the legacy IS-04 connection management is not supported and deprecated).
 
-This specification defines four new transport parameters to be used in a PATCH request:
+This specification defines new transport parameters to be used in a PATCH request:
 
-* `broker_topic`
-* `connection_uri`
 * `ext_is_07_rest_api_url`
 * `ext_is_07_source_id`
 

--- a/docs/5.1. Transport - MQTT.md
+++ b/docs/5.1. Transport - MQTT.md
@@ -80,4 +80,6 @@ This should be the `connection_lost` message described in [Message types - The c
 
 ## 7. Broker discovery
 
-The MQTT broker will be advertised via the DNS-SD service type `_nmos-mqtt._tcp`.
+The default MQTT broker should be advertised via the DNS-SD service type `_nmos-mqtt._tcp`.
+
+Each DNS-SD advertisement of this service type should be accompanied by a TXT record of name `api_proto` with a value of either `mqtt` or `secure-mqtt`, in order to indicate whether the service instance is using TLS on the port.

--- a/docs/5.1. Transport - MQTT.md
+++ b/docs/5.1. Transport - MQTT.md
@@ -82,4 +82,5 @@ This should be the `connection_lost` message described in [Message types - The c
 
 The default MQTT broker should be advertised via the DNS-SD service type `_nmos-mqtt._tcp`.
 
-Each DNS-SD advertisement of this service type should be accompanied by a TXT record of name `api_proto` with a value of either `mqtt` or `secure-mqtt`, in order to indicate whether the service instance is using TLS on the port.
+Each DNS-SD advertisement of this service type must be accompanied by a TXT record of name `api_proto` to indicate the transport protocol underlying MQTT.
+A value of `mqtt` indicates MQTT over TCP/IP, while a value of `secure-mqtt` indicates that the service instance is using TLS on the port.

--- a/docs/5.1. Transport - MQTT.md
+++ b/docs/5.1. Transport - MQTT.md
@@ -24,14 +24,41 @@ NMOS resources using MQTT will use the `urn:x-nmos:transport:mqtt` transport.
 
 Only IS-05 connection management is to be used for connection management of resources defined in this specification.
 
-### 3.1 broker_topic
+### 3.1 destination_host, destination_port, source_host, source_port
+
+These two pairs of parameters define the address of the MQTT broker for senders and receivers respectively.
+As specified in IS-05, if the parameters are set to "auto" the sender or receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. 
+This specification recommends setting the default based on the mechanism described in [Broker discovery](#7-broker-discovery).
+
+For both senders and receivers, an empty constraint object may be appropriate for this parameter.
+
+### 3.2 broker_topic
 
 The `broker_topic` parameter holds the MQTT topic and will always be set to the source id, prefixed with `x-nmos/source/` for easier filtering.
 
 For a sender, this value is intended to be static. This means the IS-05 constraints should list the static value in an 'enum' for this parameter.
 For a receiver, an empty constraint object may be appropriate for this parameter.
 
-### 3.2 ext_is_07_rest_api_url
+### 3.3 broker_protocol
+
+The `broker_protocol` parameter provides an indication of whether TLS is used for communication with the broker.
+As specified in IS-05:
+* "mqtt" indicates operation without TLS, and "secure-mqtt" indicates use of TLS.
+* If the parameter is set to "auto" the sender or receiver should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.
+This specification recommends setting the default based on the `api_proto` value described in [Broker discovery](#7-broker-discovery).
+
+For senders and receivers that do not support both protocols, the IS-05 constraints should list the supported value in an 'enum' for this parameter.
+
+### 3.4 broker_authorization
+
+The `broker_authorization` parameter is a boolean value which indicates whether authorization is used for communication with the broker.
+As specified in IS-05:
+* If the parameter is set to "auto" the sender or receiver should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.
+This specification recommends setting the default based on the `api_auth` value described in [Broker discovery](#7-broker-discovery).
+
+For senders and receivers that do not support both modes, the IS-05 constraints should list the supported value in an 'enum' for this parameter.
+
+### 3.5 ext_is_07_rest_api_url
 
 The `ext_is_07_rest_api_url` parameter represents the URL to the Events API resource which offers the current state and type of an event emitter (source) (see [Events API](6.0.%20Event%20and%20tally%20rest%20api.md))
 
@@ -59,7 +86,7 @@ Example of IS-05 PATCH request on a receiver:
 }
 ```
 
-### 3.3 Disconnecting/Parking
+### 3.6 Disconnecting/Parking
 
 A disconnection IS-05 PATCH request should always trigger the receiver to unsubscribe from the associated `broker_topic`.
 
@@ -82,5 +109,12 @@ This should be the `connection_lost` message described in [Message types - The c
 
 The default MQTT broker should be advertised via the DNS-SD service type `_nmos-mqtt._tcp`.
 
+**api\_proto**
+
 Each DNS-SD advertisement of this service type must be accompanied by a TXT record of name `api_proto` to indicate the transport protocol underlying MQTT.
-A value of `mqtt` indicates MQTT over TCP/IP, while a value of `secure-mqtt` indicates that the service instance is using TLS on the port.
+A value of `mqtt` indicates MQTT over TCP/IP, while a value of `secure-mqtt` indicates that the broker is using TLS on the port.
+
+**api\_auth**
+
+Each DNS-SD advertisement of this service type must be accompanied by a TXT record of name `api_auth` to indicate whether authorization is required in order to interact with the broker.
+The value must be either the string `true` or the string `false`.

--- a/docs/5.2. Transport - Websocket.md
+++ b/docs/5.2. Transport - Websocket.md
@@ -38,7 +38,15 @@ Filtering is achieved using the subscription mechanism explained in the followin
 For a sender, this value is intended to be static. This means the IS-05 constraints should list the static value in an 'enum' for this parameter.
 For a receiver, an empty constraint object may be appropriate for this parameter.
 
-### 3.2 ext_is_07_rest_api_url
+### 3.2 connection_authorization
+
+The `connection_authorization` parameter is a boolean value which indicates whether authorization is used for communication with the WebSocket server.
+As specified in IS-05:
+* If the parameter is set to "auto" the sender or receiver should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.
+
+For senders and receivers that do not support both modes, the IS-05 constraints should list the supported value in an 'enum' for this parameter.
+
+### 3.3 ext_is_07_rest_api_url
 
 The `ext_is_07_rest_api_url` transport parameter represents the URL to the Events API resource which offers the current state and type of an event emitter (source) (see [Events API](6.0.%20Event%20and%20tally%20rest%20api.md))
 
@@ -47,7 +55,7 @@ For a receiver, an empty constraint object may be appropriate for this parameter
 
 The use of "auto" is not defined for this parameter.
 
-### 3.3 ext_is_07_source_id
+### 3.4 ext_is_07_source_id
 
 The `ext_is_07_source_id` transport parameter represents the source id which is the emitter of the event. This is required for the WebSocket client to be able to build the subscriptions required from the server. Furthermore, the source id is required to filter and help the client determine which of the connected receivers needs to be notified when an event is consumed.
 

--- a/examples/connectionapi-v1.1-receiver-active-get-mqtt-200.json
+++ b/examples/connectionapi-v1.1-receiver-active-get-mqtt-200.json
@@ -13,6 +13,8 @@
   "transport_params": [{
     "source_host": "broker.mydomain.com",
     "source_port": 1883,
+    "broker_protocol": "mqtt",
+    "broker_authorization": false,
     "broker_topic": "my_topic_name",
     "ext_is_07_rest_api_url": "http://hostname/x-nmos/events/v1.0/sources/6cbd0441-7882-44cd-9557-842243a0d618"
   }]

--- a/examples/connectionapi-v1.1-receiver-active-get-websocket-200.json
+++ b/examples/connectionapi-v1.1-receiver-active-get-websocket-200.json
@@ -12,6 +12,7 @@
   },
   "transport_params": [{
     "connection_uri": "ws://hostname/x-nmos/events/v1.0/devices/58f6b536-ca4c-43fd-880a-9df2501fc125",
+    "connection_authorization": false,
     "ext_is_07_rest_api_url": "http://hostname/x-nmos/events/v1.0/sources/6cbd0441-7882-44cd-9557-842243a0d618",
     "ext_is_07_source_id": "6cbd0441-7882-44cd-9557-842243a0d618"
   }]

--- a/examples/connectionapi-v1.1-sender-active-get-mqtt-200.json
+++ b/examples/connectionapi-v1.1-sender-active-get-mqtt-200.json
@@ -9,6 +9,8 @@
   "transport_params": [{
     "destination_host": "broker.mydomain.com",
     "destination_port": 1883,
+    "broker_protocol": "mqtt",
+    "broker_authorization": false,
     "broker_topic": "my_topic_name",
     "ext_is_07_rest_api_url": "http://hostname/x-nmos/events/v1.0/sources/6cbd0441-7882-44cd-9557-842243a0d618"
   }]

--- a/examples/connectionapi-v1.1-sender-active-get-websocket-200.json
+++ b/examples/connectionapi-v1.1-sender-active-get-websocket-200.json
@@ -8,6 +8,7 @@
   },
   "transport_params": [{
     "connection_uri": "ws://hostname/x-nmos/events/v1.0/devices/58f6b536-ca4c-43fd-880a-9df2501fc125",
+    "connection_authorization": false,
     "ext_is_07_rest_api_url": "http://hostname/x-nmos/events/v1.0/sources/6cbd0441-7882-44cd-9557-842243a0d618",
     "ext_is_07_source_id": "6cbd0441-7882-44cd-9557-842243a0d618"
   }]


### PR DESCRIPTION
As discussed in #54.

The spec describes how the default MQTT broker host/port is advertised via DNS-SD using the service type `_nmos-mqtt._tcp`.

It would be useful to indicate whether an advertised service instance was MQTT or MQTT-over-TLS, especially in the case that the default ports (1883 for MQTT, and 8883 for MQTT-over-TLS) are not being used.

This is similar to how IS-04 advertisements for e.g. `_nmos-query._tcp` indicate whether the Query API protocol is HTTP or HTTPS via a TXT record `api_proto`.

The MQTT spec refers to the IANA registered service name as "secure-mqtt" so I have therefore used this value rather than "mqtts" to indicate the secure variant.

In the future "ws" and "wss" might be permitted to indicate MQTT-over-WebSocket.
