### PR TITLE
Add missing brace to message_connection_status

### DIFF
--- a/APIs/schemas/message_connection_status.json
+++ b/APIs/schemas/message_connection_status.json
@@ -17,5 +17,6 @@
     "active": {
       "description": "A boolean value showing whether the MQTT client is connected to the broker.",
       "type": "boolean"
+    }
   }
 }


### PR DESCRIPTION
This will fix #64, though should it be back-ported to any branch/tag that gets rendered on gh-pages, as it will break the schema resolving?