### PR TITLE
Clarify that min and max are inclusive and remove the unintended default value of step

### DIFF
--- a/docs/3.0. Event types.md
+++ b/docs/3.0. Event types.md
@@ -103,13 +103,13 @@ In addition to the mandatory `value` field, an optional `scale` field is introdu
 This event type is associated with a type definition object that is used to specify the following:
 
 * a `scale` field indicating the denominator typically used for rational numbers in the event payload [optional]
-* minimum value [mandatory]
-* maximum value [mandatory]
-* step value [optional] (default = 1)
+* minimum (inclusive) value [mandatory]
+* maximum (inclusive) value [mandatory]
+* step value [optional]
 * measurement unit [optional]
 
 The value of the optional `step` field indicates the precision.
-The value of `max - min` should be an integer multiple of `step` (taking account the `value` and `scale` of each).
+When `step` is specified, the value of `max - min` should be an integer multiple of `step` (taking account the `value` and `scale` of each).
 Similarly, for each event, `payload - min` should be an integer multiple of `step`.
 The `scale` field of `min`, `max`, `step`, and each event `payload`, are typically the same.
 


### PR DESCRIPTION
Resolves #67.

I didn't add any descriptions to the type_number.json schema itself mostly due to [JSON Schema draft-04 making that harder than necessary](https://stackoverflow.com/questions/33565090/json-schema-property-description-and-ref-usage).