### PR TITLE
Delete 'flow_id' from doc example Events API response

### DIFF
--- a/docs/6.0. Event and tally rest api.md
+++ b/docs/6.0. Event and tally rest api.md
@@ -79,8 +79,7 @@ Example response:
 ```json
 {
   "identity": {
-    "source_id": "a65c15a4-a52e-4960-8cd2-e05c31196e5f",
-    "flow_id": "ff455cf3-fb17-448b-8f4c-e6c0e294f5ed"
+    "source_id": "a65c15a4-a52e-4960-8cd2-e05c31196e5f"
   },
   "timing": {
     "creation_timestamp": "1529323551:016020406",


### PR DESCRIPTION
To match the spec: [The state message type](https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/2.0.%20Message%20types.md#11-the-state-message-type):

"The `flow_id` will NOT be included in the response to a REST API query for the state via the Events API because the state is held by the source which has no dependency on a flow. It will, however, appear when being sent through one of the two specified transports because it will pass from the source through a flow and out on the network through the sender."
