### PR TITLE
Make use of retained flags consistent and require connection status behaviour if supported

### DIFF
--- a/APIs/schemas/message_connection_status.json
+++ b/APIs/schemas/message_connection_status.json
@@ -2,7 +2,7 @@
   "$id": "https://www.amwa.tv/event_and_tally/message_connection_status.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "description": "Message that indicates the status of the connection between the MQTT client and the broker. The topic used is connection specific and has to be specified in the connection_status_broker_topic parameter of the MQTT IS-05 transport parameters object. The client should publish this message with the RETAIN flag set, after opening the connection to the broker and before closing the connection normally. The client should also configure a retained Will Message indicating it is disconnected.",
+  "description": "Message that indicates the status of the connection between the MQTT client and the broker. If connection status messages are used, the publishing topic is connection specific and must be specified in the connection_status_broker_topic parameter of the MQTT IS-05 transport parameters object. The client must publish this message with the RETAIN flag set, after opening the connection to the broker and before closing the connection normally. The client must also configure a retained Will Message indicating it is disconnected.",
   "title": "Connection status message",
   "required": [
     "message_type",

--- a/docs/2.0. Message types.md
+++ b/docs/2.0. Message types.md
@@ -25,7 +25,7 @@ For the MQTT transport, the publishing topic is specified below for each message
 
 The `state` message type is always sent when the emitter changes state and issues a new event, and is also used in response to a REST API query for the state via the [Events API](6.0.%20Event%20and%20tally%20rest%20api.md).  
 These will be the predominant message types being sent in an Event & Tally system.
-With the MQTT transport, this message must use the `broker_topic` parameter as the publishing topic. The *RETAIN flag* should be set.
+With the MQTT transport, this message must use the `broker_topic` parameter as the publishing topic. The *RETAIN flag* must be set.
 
 The message structure shall have the following items:
 
@@ -130,7 +130,11 @@ The `"creation_timestamp"` represents the timestamp at which the emitter establi
 
 The `connection_status` message is used to indicate the status of the connection between the MQTT client and the broker.
 It is only used with the [MQTT transport](5.1.%20Transport%20-%20MQTT.md)).
-This message must use the `connection_status_broker_topic` parameter as the publishing topic. The *RETAIN flag* should be set.
+Support for connection status messages is recommended.
+The `connection_status_broker_topic` parameter is `null` if connection status messages are not used.
+
+For a sender that indicates a non-null `connection_status_broker_topic`, the sender client must publish connection status messages.
+This message must use the `connection_status_broker_topic` parameter as the publishing topic. The *RETAIN flag* must be set.
 
 The message structure shall have the following items:
 
@@ -148,10 +152,10 @@ Message structure
 
 The `"active"` flag indicates to subscribers whether the client has a connection to the broker.
 
-The client should publish this message with `"active"` set to true, after opening the connection to the broker.
+The client must publish this message with `"active"` set to true, after opening the connection to the broker.
 
-Similarly, the client should publish this message with `"active"` set to false, before closing the connection to the broker normally with a *DISCONNECT packet*.
-In order that this message is published even if the client's connection is not closed normally, the client should specify a retained *Will Message* of this type, in the initial *CONNECT packet*.
+The client must publish this message with `"active"` set to false, before closing the connection to the broker normally with a *DISCONNECT packet*.
+In order that this message is published even if the client's connection is not closed normally, the client must specify a retained *Will Message* of this type, in the initial *CONNECT packet*.
 (With MQTT Version 5.0, the client can just request the broker to publish the *Will Message* after closing the connection normally, by using *Disconnect wth Will Message* in the *DISCONNECT packet*.)
 
 For more information about *Will Messages* consult the MQTT specification and other MQTT materials:

--- a/docs/5.1. Transport - MQTT.md
+++ b/docs/5.1. Transport - MQTT.md
@@ -47,7 +47,10 @@ Message types (see [Message types](2.0.%20Message%20types.md)) which use this pa
 
 ### 3.3 connection_status_broker_topic
 
-The `connection_status_broker_topic` parameter holds the sender's MQTT connection status topic. The recommended format is `x-nmos/events/{version}/connections/{connectionId}`.  
+Support for connection status messages is recommended.
+
+The `connection_status_broker_topic` parameter holds the sender's MQTT connection status topic, or `null` if connection status messages are not used.
+The recommended string format is `x-nmos/events/{version}/connections/{connectionId}`.  
 The `{version}` is the version of this specification, e.g. `v1.0`.
 The `{connectionId}` can be one of the following:
 
@@ -123,10 +126,11 @@ If multiple receivers share a connection to the broker then it is up to the impl
 If the client does not currently have a connection to the MQTT broker indicated by `destination_host` and `destination_port` (for senders) or `source_host` and `source_port` (for receivers), it opens a connection.
 The `broker_protocol` and `broker_authorization` indicate how the connection should be negotiated.
 
-A sender client should specify a `connection_status` message with `"active"` set to false, as a retained *Will Message* in the *CONNECT packet*, using the `connection_status_broker_topic`.
-The sender client should then publish a retained `connection_status` message with `"active"` set to true, using the `connection_status_broker_topic`.
+For a sender that indicates a non-null `connection_status_broker_topic`, the sender client must publish connection status messages:
+* It must specify a `connection_status` message with `"active"` set to false, as a retained *Will Message* in the *CONNECT packet*, using the `connection_status_broker_topic`.
+* It must then publish a retained `connection_status` message with `"active"` set to true, using the `connection_status_broker_topic`.
 
-If a receiver client does not already do so, it should subscribe to the `connection_status_broker_topic`.
+If a receiver client does not already do so, it should subscribe to the `connection_status_broker_topic` if non-null.
 
 #### Step 2
 
@@ -144,7 +148,7 @@ The client continues to receive events from all the sources to which it is subsc
 
 #### Step 5
 
-When disconnecting from the broker, a sender client should publish a retained `connection_status` message with `"active"` set to false, using the `connection_status_broker_topic`.
+If the client published a connection status message when connecting, it must publish a retained `connection_status` message with `"active"` set to false when disconnecting from the broker, using the `connection_status_broker_topic`.
 (With MQTT Version 5.0, the client can just request the broker to publish the *Will Message* after closing the connection normally, by using *Disconnect wth Will Message* in the *DISCONNECT packet*.)
 
 ## 4. QoS Settings
@@ -159,7 +163,7 @@ Consumers (receivers) have a choice to either use the retained message or query 
 
 ## 6. MQTT Will Message
 
-All event emitters (MQTT publishers) should specify a retained *Will Message* using the `connection_status_broker_topic` parameter as the publishing topic, as described in [Message types - The connection status message type](2.0.%20Message%20types.md#14-the-connection-status-message-type).
+All event emitters (MQTT publishers) that publish `connection_status` messages must specify a retained *Will Message* using the `connection_status_broker_topic` parameter as the publishing topic, as described in [Message types - The connection status message type](2.0.%20Message%20types.md#14-the-connection-status-message-type).
 
 ## 7. Broker discovery
 


### PR DESCRIPTION
### Make use of retained flags consistent
https://amwa-tv.github.io/nmos-event-tally/tags/v1.0.1/docs/2.0._Message_types.html#11-the-state-message-type states:

> The RETAIN flag should be set.

https://amwa-tv.github.io/nmos-event-tally/tags/v1.0.1/docs/5.1._Transport_-_MQTT.html#5-late-joiners states: 

> MQTT publishers are required to set the RETAIN flag with every state message

This PR makes the retain flag consistently required on all messages.

### Make the connection status behaviour required if supported

Currently all the connection status message behaviour is specified with `should`, this PR changes it to make specifying a connection status topic recommended but if a topic is specified the connection status behaviour is all mandatory.